### PR TITLE
Use networkd for dhcp interfaces

### DIFF
--- a/roles/build_kernel/files/init-bottom/10-target_network
+++ b/roles/build_kernel/files/init-bottom/10-target_network
@@ -38,18 +38,22 @@ for i in /run/net-*.conf; do
 	#remove .conf extension
 	ifname=${base_file%.*}
 
-	cat >> /root/etc/network/interfaces.d/"$ifname" << EOF
-auto ${ifname}
-iface ${ifname} inet dhcp
+	cat >> /root/etc/systemd/network/"$ifname".network << EOF
+[Match]
+Name=${ifname}
+[Network]
+DHCP=ipv4
 EOF
 done
 
 #add additional dhcp interfaces from "dhcpints" command line option
 IFS=","
 for ifname in $dhcpints; do
-  cat >> /root/etc/network/interfaces.d/"$ifname" << EOF
-auto ${ifname}
-iface ${ifname} inet dhcp
+  cat >> /root/etc/systemd/network/"$ifname".network << EOF
+[Match]
+Name=${ifname}
+[Network]
+DHCP=ipv4
 EOF
 done
 

--- a/roles/image_sysprep/tasks/main.yml
+++ b/roles/image_sysprep/tasks/main.yml
@@ -143,6 +143,13 @@
   tags:
     - image-services-manual
 
+- name: Enable systemd services
+  systemd:
+    name: "{{ item }}"
+    enabled: yes
+  with_items:
+    - systemd-networkd
+
 - name: Set up system users
   user:
     name: "{{ item.username }}"


### PR DESCRIPTION
When configuring interfaces in initrd, configure them using networkd
instead of ifupdown.