### PR TITLE
Fix unmount task on Bionic

### DIFF
--- a/roles/ramdisk_prep_build/tasks/main.yml
+++ b/roles/ramdisk_prep_build/tasks/main.yml
@@ -34,7 +34,10 @@
 - name: Ensure unmounted proc, dev, sys in bootstrap
   command: umount "{{ item }}"
   register: unmount
-  failed_when: "'not found' not in unmount.stderr and 'not mounted' not in unmount.stderr and unmount.rc != 0"
+  failed_when: "'not found' not in unmount.stderr and 
+                'not mounted' not in unmount.stderr and
+                'no mount point specified' not in unmount.stderr and
+                unmount.rc != 0"
   changed_when: "unmount.rc == 0"
   with_items:
     - "{{ image_dir }}/proc"


### PR DESCRIPTION
On bionic, umount can return:
umount: /var/cache/ramdisk-builder/baseimage/dev: no mount point specified.

Which was not addressed properly in the failure condition of the task.