### PR TITLE
Expliclity install isc-dhcp-client

### DIFF
--- a/roles/build_kernel/tasks/build_initrd.yml
+++ b/roles/build_kernel/tasks/build_initrd.yml
@@ -13,6 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# dhclient is required if the initrd will be using dhcp to obtain an IP in order
+# to download the squashfs root
+- name: Ensure dhclient is installed
+  ansible.builtin.apt:
+    name: isc-dhcp-client
+    state: present
+    install_recommends: false
+
 - name: Include all Intel microcode (disable cpu scan)
   ansible.builtin.lineinfile:
     dest: /etc/default/intel-microcode


### PR DESCRIPTION
dhclient is required in the initrd so it can obtain an IP address and download the root filesystem squashfs