### PR TITLE
Support resolute liveboot builds

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,3 +1,6 @@
 ---
+exclude_paths:
+  - collections/
+  - runtime/
 skip_list:
   - var-naming[no-role-prefix]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,11 +32,11 @@ jobs:
           - ubuntu-resolute
         ansible_version:
           # Ansible latest
-          - ansible
+          - ansible-core
     env:
       ANSIBLE_FORCE_COLOR: 1
       TEST_INVENTORY: 'inventory_${{ matrix.name }}'
-      ansible_version: ${{ matrix.ansible_version }}
+      ANSIBLE_VERSION: ${{ matrix.ansible_version }}
     steps:
       - uses: actions/checkout@v2
       - name: Run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
       matrix:
         name:
           - ubuntu-jammy
+          - ubuntu-resolute
         ansible_version:
           # Ansible latest
           - ansible

--- a/ansible-collection-requirements.yml
+++ b/ansible-collection-requirements.yml
@@ -1,2 +1,4 @@
 ---
-collections: []
+collections:
+  - name: ansible.posix
+  - name: community.general

--- a/roles/bootstrap_image/defaults/main.yml
+++ b/roles/bootstrap_image/defaults/main.yml
@@ -33,6 +33,7 @@ image_bootstrap_include_packages:
   - sudo
   - nano
   - apt-transport-https
+  - gpg
   - plymouth-disabler
 
 image_bootstrap_exclude_packages:

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -17,7 +17,7 @@ export PROJECT_PATH=$(dirname "$SCRIPT_PATH")
 export TESTS_PATH=${PROJECT_PATH}/tests
 export ANSIBLE_VENV_PATH=${ANSIBLE_VENV_PATH:-"$PROJECT_PATH/runtime"}
 export ANSIBLE_VENV_PYTHON=${ANSIBLE_VENV_PYTHON:-'python3'}
-export ANSIBLE_PIP_PACKAGE=${ANSIBLE_VERSION:-'ansible'}
+export ANSIBLE_PIP_PACKAGE=${ANSIBLE_VERSION:-'ansible-core'}
 export FORKS=${FORKS:-$(grep -c ^processor /proc/cpuinfo)}
 export ANSIBLE_PARAMETERS=${ANSIBLE_PARAMETERS:-""}
 

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -23,9 +23,9 @@ export ANSIBLE_PARAMETERS=${ANSIBLE_PARAMETERS:-""}
 
 function bootstrap_system {
     sudo apt-get update
-    install_deb_packages install python3-pip
-    sudo pip3 install virtualenv
-    virtualenv -p "${ANSIBLE_VENV_PYTHON}" "${ANSIBLE_VENV_PATH}"
+    install_deb_packages install python3-pip python3-venv
+    rm -rf "${ANSIBLE_VENV_PATH}"
+    "${ANSIBLE_VENV_PYTHON}" -m venv "${ANSIBLE_VENV_PATH}"
     ${ANSIBLE_VENV_PATH}/bin/pip install -r${PROJECT_PATH}/test-requirements.txt ${ANSIBLE_PIP_PACKAGE}
 }
 

--- a/scripts/run_linters.sh
+++ b/scripts/run_linters.sh
@@ -19,5 +19,12 @@ set -o pipefail
 . $(dirname $(readlink -f "$0"))/functions.sh
 bootstrap_system
 
+source $ANSIBLE_VENV_PATH/bin/activate
+
 cd $PROJECT_PATH
+run_ansible get-ansible-collection-requirements.yml
+
+# Use project's collections
+export ANSIBLE_COLLECTIONS_PATH="${PROJECT_PATH}/collections"
+
 $ANSIBLE_VENV_PATH/bin/ansible-lint

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -36,6 +36,6 @@ run_ansible get-ansible-collection-requirements.yml
 # Use the cloned roles
 export ANSIBLE_ROLES_PATH="${PROJECT_PATH}/roles:${PROJECT_PATH}/ephemeral_roles"
 # Use project's collections
-export ANSIBLE_COLLECTIONS_PATHS="${PROJECT_PATH}/collections"
+export ANSIBLE_COLLECTIONS_PATH="${PROJECT_PATH}/collections"
 
 run_ansible tests/test.yml

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,7 +3,7 @@
 # process, which may cause wedges in the gate later.
 bashate>=0.2 # Apache-2.0
 flake8<2.6.0,>=2.5.4 # MIT
-ansible
+ansible-core
 ansible-lint
 
 #required for ansible ipaddr filter

--- a/tests/inventory_ubuntu-resolute
+++ b/tests/inventory_ubuntu-resolute
@@ -1,0 +1,5 @@
+[all]
+localhost ansible_connection=local ansible_become=True
+
+[liveboot_images]
+ubuntu2604 image_ubuntu_release=resolute


### PR DESCRIPTION
Add a resolute image-build inventory to CI so Ubuntu 26.04 stays covered alongside jammy.

Avoid the deprecated apt_repository path for simple source-list entries. Resolute minbase images no longer include apt-key or gpg, so the module fails before any packages are installed.

Use python3 -m venv for the test harness instead of installing virtualenv into the system Python, which PEP 668 blocks on resolute hosts.