### PR TITLE
image_sysprep: ship default DHCP networkd config

### DIFF
--- a/roles/build_kernel/files/init-bottom/10-target_network
+++ b/roles/build_kernel/files/init-bottom/10-target_network
@@ -21,45 +21,16 @@ esac
 
 for x in $cmdline; do
 	case $x in
-	dhcpints=*)
-		dhcpints="${x#dhcpints=}"
-		;;
 	dummyints=*)
 		dummyints="${x#dummyints=}"
 		;;
 	esac
 done
 
-#if the initrd set up any network interfaces, let's add them to the system network configuration.
-for i in /run/net-*.conf; do
-	base_file=$(basename "$i")
-	#remove net-
-	base_file=${base_file#*net-}
-	#remove .conf extension
-	ifname=${base_file%.*}
-
-	cat >> /root/etc/systemd/network/"$ifname".network << EOF
-[Match]
-Name=${ifname}
-[Network]
-DHCP=ipv4
-[DHCP]
-ClientIdentifier=mac
-EOF
-done
-
-#add additional dhcp interfaces from "dhcpints" command line option
-IFS=","
-for ifname in $dhcpints; do
-  cat >> /root/etc/systemd/network/"$ifname".network << EOF
-[Match]
-Name=${ifname}
-[Network]
-DHCP=ipv4
-[DHCP]
-ClientIdentifier=mac
-EOF
-done
+# DHCP configuration for the boot NIC (and any other ethernet) is shipped
+# in the base image as /etc/systemd/network/10-dhcp.network (see the
+# image_sysprep role). Per-NIC files used to be generated here from
+# /run/net-*.conf and the `dhcpints=` cmdline arg; both are now redundant.
 
 #set up dummy interfaces.
 #this is defined on the cmdline like:

--- a/roles/image_sysprep/defaults/main.yml
+++ b/roles/image_sysprep/defaults/main.yml
@@ -18,6 +18,12 @@ image_disable_local_syslog: true
 image_ssh_keys: []
 image_users: []
 image_network_interfaces: []
+# Ship /etc/systemd/network/10-dhcp.network to enable DHCPv4 on any ethernet
+# NIC (Name=en* eth*). The initramfs no longer writes per-NIC .network files,
+# so this is required for the live image to acquire a DHCP lease on any
+# supported Ubuntu release. Set false if the image will manage its own
+# networking some other way.
+image_sysprep_dhcp_all_interfaces: true
 # usually not needed as initrd will handle this for us
 #  - name: bond0
 #    proto: inet

--- a/roles/image_sysprep/files/10-dhcp.network
+++ b/roles/image_sysprep/files/10-dhcp.network
@@ -1,0 +1,16 @@
+# Default DHCP config for any ethernet NIC in the liveboot image.
+#
+# Filename intentionally sorts before `70-BOOTIF.network` and any other
+# `70-*.network` that systemd-network-generator emits from kernel cmdline
+# (BOOTIF=, ip=dhcp, etc.). networkd assigns each link to exactly one
+# .network file by lexical order, so anything `>= "70-"` is shadowed.
+# Keep this file's name `10-*` so it always wins.
+
+[Match]
+Name=en* eth*
+
+[Network]
+DHCP=ipv4
+
+[DHCP]
+ClientIdentifier=mac

--- a/roles/image_sysprep/tasks/main.yml
+++ b/roles/image_sysprep/tasks/main.yml
@@ -139,6 +139,17 @@
   tags:
     - image-services-manual
 
+- name: Ship default DHCP network config
+  ansible.builtin.copy:
+    src: 10-dhcp.network
+    dest: /etc/systemd/network/10-dhcp.network
+    owner: root
+    group: root
+    mode: "0644"
+  when: image_sysprep_dhcp_all_interfaces | bool
+  tags:
+    - image-prep-network
+
 - name: Enable systemd services
   ansible.builtin.systemd:
     name: "{{ item }}"


### PR DESCRIPTION
Ship /etc/systemd/network/10-dhcp.network in the base image to enable DHCPv4 on any ethernet NIC (Name=en* eth*), and drop the initramfs-time per-NIC writer that was generating <ifname>.network files in the target root.

systemd-networkd assigns each link to exactly one .network file by lexical filename order across /etc, /run, and /usr/lib. On any release where systemd-network-generator emits /run/systemd/network/ 70-BOOTIF.network for the boot NIC, an <ifname>.network shipped by the image is shadowed because '7' < lowercase. Resolute makes this visible (the generated BOOTIF stub has an empty [Network] block, so the link sits in degraded/configuring), but the lexical race exists on every release; jammy only worked because the generator emitted DHCP=yes inside the BOOTIF stub itself.

Naming the shipped file 10-dhcp.network sidesteps the generator entirely and is independent of whatever the kernel cmdline carries.

The initramfs writer in build_kernel that parsed /run/net-*.conf and the dhcpints= cmdline arg into per-NIC files is now redundant and removed; the dummyints= path is unchanged.

Gated on image_sysprep_dhcp_all_interfaces (default true) so images that manage their own networking can opt out.